### PR TITLE
add option to force template .Dir be the path of a local module

### DIFF
--- a/cmd/gomarkdoc/README.md
+++ b/cmd/gomarkdoc/README.md
@@ -15,7 +15,7 @@ See https://github.com/Weborama/gomarkdoc for full documentation of this tool.
 - [type PackageSpec](<#type-packagespec>)
 
 
-## type [PackageSpec](<https://github.com/Weborama/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L30-L44>)
+## type [PackageSpec](<https://github.com/Weborama/gomarkdoc/blob/master/cmd/gomarkdoc/command.go#L31-L45>)
 
 PackageSpec defines the data available to the \-\-output option's template. Information is recomputed for each package generated.
 

--- a/cmd/gomarkdoc/command.go
+++ b/cmd/gomarkdoc/command.go
@@ -502,27 +502,25 @@ func getLocalDir(path, fullModule string) string {
 }
 
 func getFullPackageName(opts commandOptions) (string, error) {
-	var fullPackageName string
-
-	if opts.forceLocalDir {
-		if opts.fullPackageName != "" {
-			fullPackageName = opts.fullPackageName
-		} else {
-			data, err := os.ReadFile("go.mod")
-			if err != nil {
-				return "", fmt.Errorf("unable to read module file: %w", err)
-			}
-
-			f, err := modfile.Parse("go.mod", data, nil)
-			if err != nil {
-				return "", fmt.Errorf("unable to parse module file: %w", err)
-			}
-
-			fullPackageName = f.Module.Mod.String()
-		}
+	if !opts.forceLocalDir {
+		return "", nil
 	}
 
-	return fullPackageName, nil
+	if opts.fullPackageName != "" {
+		return opts.fullPackageName, nil
+	}
+
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		return "", fmt.Errorf("unable to read module file: %w", err)
+	}
+
+	f, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse module file: %w", err)
+	}
+
+	return f.Module.Mod.String(), nil
 }
 
 func getSpecs(opts commandOptions, paths ...string) ([]*PackageSpec, error) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	golang.org/x/mod v0.21.0
 	mvdan.cc/xurls/v2 v2.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
# how it works

If we define a list of local packages (format path like in the output of `go list -f '{{ .Dir }}' ./...`) and use the output as template `{{ .Dir }}/README.md` we can use one single command execution to generate the docs for all packages.

Unfortunately, on versioned modules, it does not understand the package name + version (v1, v2 ...) and it generates wrong documentation.

the workaround is to add a comment in the package like

```go
package foo // import "gitlab.nereides.weborama.com/go/my-project/v666/foo"

```

However this requires a massive rewrite on all source code and... it is kinda _ugly_

A better solution seems to list the packages as remote packages ( like using `go list ./...`), however if we do this, the `.Dir` attribute will be hard coded `.` and all files will be generated as the current README.md (last wins)

by adding an new option `--force-local-dir` we:

1. open the `go.mod` file and parse the content
2. use the package name to find the relative path to the package
3. profit

IF we want to avoid parse the `go.mod` file, we can specify the full package name with version like this, using the new option `--full-package-name`:

```console
$ go list ./...|xargs /usr/bin/time -p ../../../github.com/Weborama/gomarkdoc/bin/gomarkdoc --force-relative-urls --output "{{ .Dir }}/README.md" --force-local-dir --full-package-name gitlab.nereides.weborama.com/go/wdx2-libs/v5
...
```

testing on project wdx2-libs:

# using current go.mk

- running `make docs`

```console
$ time -p make docs
...
==== Creating/updating gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue/README.md
/home/tiago/work/go/bin/gomarkdoc --force-relative-urls --output=/home/tiago/work/go/src/gitlab.nereides.weborama.com/go/wdx2-libs/wqueue/README.md gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue
real 30,58
user 76,79
sys 24,69
```

- running `make docs_check`

```console
$ time -p make docs_check
...
==== Checking gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue/README.md
/home/tiago/work/go/bin/gomarkdoc --force-relative-urls --check --output=/home/tiago/work/go/src/gitlab.nereides.weborama.com/go/wdx2-libs/wqueue/README.md gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue
real 30,51
user 78,09
sys 24,89
```

# using current go.mk with option `-j` to run in parallel

- running `make docs` 

```console
$ time -p make -j docs
...
==== Creating/updating gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue/README.md
/home/tiago/work/go/bin/gomarkdoc --force-relative-urls --output=/home/tiago/work/go/src/gitlab.nereides.weborama.com/go/wdx2-libs/wqueue/README.md gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue
real 20,21
user 73,95
sys 25,75
```

- running `make docs_check`

```console
$ time -p make -j docs_docs
...
==== Checking gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue/README.md
/home/tiago/work/go/bin/gomarkdoc --force-relative-urls --check --output=/home/tiago/work/go/src/gitlab.nereides.weborama.com/go/wdx2-libs/wqueue/README.md gitlab.nereides.weborama.com/go/wdx2-libs/v5/wqueue
real 17,86
user 63,35
sys 22,50
```

# new command line tool

- generate docs (like make docs)

```console
$ go list ./...|xargs /usr/bin/time -p ../../../github.com/Weborama/gomarkdoc/bin/gomarkdoc --force-relative-urls --output "{{ .Dir }}/README.md" --force-local-dir -vv
...
DEBUG found default branch devel for remote git@gitlab.nereides.weborama.com:go/wdx2-libs.git dir=./wqueue
DEBUG resolved repository with remote https://gitlab.nereides.weborama.com/go/wdx2-libs, default branch devel, path from root / dir=./wqueue
real 13.39
user 36.07
sys 11.18
```

- check if docs are ok (like make docks_check)

```console
$ go list ./...|xargs /usr/bin/time -p ../../../github.com/Weborama/gomarkdoc/bin/gomarkdoc --force-relative-urls --output "{{ .Dir }}/README.md" --force-local-dir -vv -c
...
DEBUG found default branch devel for remote git@gitlab.nereides.weborama.com:go/wdx2-libs.git dir=./wqueue
DEBUG resolved repository with remote https://gitlab.nereides.weborama.com/go/wdx2-libs, default branch devel, path from root / dir=./wqueue
real 14.20
user 39.76
sys 11.71
```

it means

1. with the new option is pretty fast generate or verify the documentation
2. since it is a new option, the program *is* backward compatible